### PR TITLE
Strengthen unit test assertions

### DIFF
--- a/src/test/java/tech/ydb/mv/apply/MvWorkerSelectorTest.java
+++ b/src/test/java/tech/ydb/mv/apply/MvWorkerSelectorTest.java
@@ -90,13 +90,56 @@ public class MvWorkerSelectorTest {
     }
 
     @Test
-    public void techSelectWorkerLoader() {
-        MvWorkerSelector sw = new SW(10);
+    public void testRangeRefreshDistributesPrefixesAcrossWorkers() {
+        SW sw = new SW(10);
         sw.refresh(null);
 
         var chooser = (MvWorkerSelector.ChooserRange) sw.getChooser();
         Assertions.assertEquals(12, chooser.getItems().size());
-        System.out.println("Chooser items: " + chooser.getItems());
+
+        MvKeyPrefix[] prefixes = sw.readPrefixes(null);
+        int[] expectedWorkers = {0, 0, 1, 2, 3, 4, 5, 5, 6, 7, 8, 9};
+        for (int i = 0; i < prefixes.length; ++i) {
+            Assertions.assertEquals(expectedWorkers[i], chooser.getItems().get(prefixes[i]),
+                    "Unexpected worker for prefix " + i);
+        }
+
+        MvKeyInfo keyInfo = sw.getKeyInfo();
+        Assertions.assertEquals(0, sw.choose(KV(YS().add("key1", 50).add("key2", 1L), keyInfo)));
+        Assertions.assertEquals(1, sw.choose(KV(YS().add("key1", 250).add("key2", 1L), keyInfo)));
+        Assertions.assertEquals(5, sw.choose(KV(YS().add("key1", 600).add("key2", 1500L), keyInfo)));
+        Assertions.assertEquals(9, sw.choose(KV(YS().add("key1", 950).add("key2", 1L), keyInfo)));
+    }
+
+    @Test
+    public void testRangeRefreshAssignsDistinctWorkersWhenWorkersOutnumberPrefixes() {
+        SW sw = new SW(20);
+        sw.refresh(null);
+
+        var chooser = (MvWorkerSelector.ChooserRange) sw.getChooser();
+        MvKeyPrefix[] prefixes = sw.readPrefixes(null);
+        for (int i = 0; i < prefixes.length; ++i) {
+            Assertions.assertEquals(i + 1, chooser.getItems().get(prefixes[i]),
+                    "Each prefix should get its own non-zero worker when capacity allows");
+        }
+
+        MvKeyInfo keyInfo = sw.getKeyInfo();
+        Assertions.assertEquals(1, sw.choose(KV(YS().add("key1", 50).add("key2", 1L), keyInfo)));
+        Assertions.assertEquals(20 - 1, sw.choose(KV(YS().add("key1", 950).add("key2", 1L), keyInfo)));
+    }
+
+    @Test
+    public void testHashSelectorUsesHashModuloAndDoesNotRefreshPrefixes() {
+        MvWorkerSelector sw = new MvWorkerSelector(makeTableInfo(), 7, MvConfig.PartitioningStrategy.HASH);
+        Assertions.assertInstanceOf(MvWorkerSelector.ChooserHash.class, sw.getChooser());
+
+        sw.refresh(null);
+        Assertions.assertInstanceOf(MvWorkerSelector.ChooserHash.class, sw.getChooser());
+
+        MvKeyInfo keyInfo = sw.getKeyInfo();
+        MvKey key = KV(YS().add("key1", 123).add("key2", 456L), keyInfo);
+        int expectedWorker = (int) (Integer.toUnsignedLong(key.hashCode()) % 7);
+        Assertions.assertEquals(expectedWorker, sw.choose(key));
     }
 
     private static MvTableInfo makeTableInfo() {

--- a/src/test/java/tech/ydb/mv/data/MvChangesMultiDictTest.java
+++ b/src/test/java/tech/ydb/mv/data/MvChangesMultiDictTest.java
@@ -225,6 +225,13 @@ public class MvChangesMultiDictTest {
         return dict;
     }
 
+    private MvRowFilter findFilter(ArrayList<MvRowFilter> filters, MvViewExpr target) {
+        return filters.stream()
+                .filter(filter -> filter.getTarget() == target)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Missing filter for " + target.getName()));
+    }
+
     @Test
     public void testSingleDictRelevantFieldChange() {
         // Test: Single dictionary with relevant field change
@@ -244,20 +251,30 @@ public class MvChangesMultiDictTest {
         }
         assertTrue(filteredTargets.contains(targetSingleDict));
         assertTrue(filteredTargets.contains(targetMultiDict));
+
+        MvRowFilter singleFilter = findFilter(filters, targetSingleDict);
+        assertEquals(1, singleFilter.getBlocks().size());
+        assertEquals(1, singleFilter.getBlocks().get(0).getStartPos());
+        assertEquals(1, singleFilter.getBlocks().get(0).getLength());
+        assertTrue(singleFilter.matches(new Comparable<?>[]{100L, 1L}));
+        assertTrue(singleFilter.matches(new Comparable<?>[]{200L, 2L}));
+        assertFalse(singleFilter.matches(new Comparable<?>[]{300L, 99L}));
+
+        MvRowFilter multiFilter = findFilter(filters, targetMultiDict);
+        assertEquals(1, multiFilter.getBlocks().size());
+        assertEquals(1, multiFilter.getBlocks().get(0).getStartPos());
+        assertEquals(1, multiFilter.getBlocks().get(0).getLength());
+        assertTrue(multiFilter.matches(new Comparable<?>[]{100L, 1L}));
+        assertFalse(multiFilter.matches(new Comparable<?>[]{300L, 99L}));
     }
 
     @Test
     public void testSingleDictNonRelevantFieldChange() {
-        // Test: Single dictionary with non-relevant field change - test individual toFilter method to avoid NPE bug
+        // Test: Single dictionary with non-relevant field change
         MvChangesSingleDict dict1Changes = createDictChanges("dict1", "description", 1L, 2L);
         changes.addItem(dict1Changes);
 
-        MvRowFilter filter1 = changes.toFilter(handler, targetSingleDict);
-        MvRowFilter filter2 = changes.toFilter(handler, targetMultiDict);
-
-        // Should return null when no relevant changes
-        assertNull(filter1);
-        assertNull(filter2);
+        assertTrue(changes.toFilters(handler).isEmpty());
     }
 
     @Test
@@ -330,18 +347,13 @@ public class MvChangesMultiDictTest {
 
     @Test
     public void testTwoDictsBothNonRelevant() {
-        // Test: Two dictionaries with non-relevant field changes - test individual toFilter method to avoid NPE bug
+        // Test: Two dictionaries with non-relevant field changes
         MvChangesSingleDict dict1Changes = createDictChanges("dict1", "description", 1L, 2L);
         MvChangesSingleDict dict2Changes = createDictChanges("dict2", "metadata", 3L, 4L);
         changes.addItem(dict1Changes);
         changes.addItem(dict2Changes);
 
-        MvRowFilter filter1 = changes.toFilter(handler, targetSingleDict);
-        MvRowFilter filter2 = changes.toFilter(handler, targetMultiDict);
-
-        // Should return null when no relevant changes
-        assertNull(filter1);
-        assertNull(filter2);
+        assertTrue(changes.toFilters(handler).isEmpty());
     }
 
     @Test
@@ -387,7 +399,7 @@ public class MvChangesMultiDictTest {
 
     @Test
     public void testThreeDictsAllNonRelevant() {
-        // Test: Three dictionaries with all non-relevant field changes - test individual toFilter method to avoid NPE bug
+        // Test: Three dictionaries with all non-relevant field changes
         MvChangesSingleDict dict1Changes = createDictChanges("dict1", "description", 1L, 2L);
         MvChangesSingleDict dict2Changes = createDictChanges("dict2", "metadata", 3L, 4L);
         MvChangesSingleDict dict3Changes = createDictChanges("dict3", "extra", 5L, 6L);
@@ -395,37 +407,26 @@ public class MvChangesMultiDictTest {
         changes.addItem(dict2Changes);
         changes.addItem(dict3Changes);
 
-        MvRowFilter filter1 = changes.toFilter(handler, targetSingleDict);
-        MvRowFilter filter2 = changes.toFilter(handler, targetMultiDict);
-
-        // Should return null when no relevant changes
-        assertNull(filter1);
-        assertNull(filter2);
+        assertTrue(changes.toFilters(handler).isEmpty());
     }
 
     @Test
     public void testEmptyChanges() {
-        // Test: No dictionary changes - test individual toFilter method to avoid NPE bug
-        MvRowFilter filter1 = changes.toFilter(handler, targetSingleDict);
-        MvRowFilter filter2 = changes.toFilter(handler, targetMultiDict);
-
-        // Should return null when no relevant changes
-        assertNull(filter1);
-        assertNull(filter2);
+        // Test: No dictionary changes
+        assertTrue(changes.isEmpty());
+        assertFalse(changes.hasKnownChanges("dict1"));
+        assertTrue(changes.toFilters(handler).isEmpty());
     }
 
     @Test
     public void testEmptyDictChanges() {
-        // Test: Dictionary changes with no field changes - test individual toFilter method to avoid NPE bug
+        // Test: Dictionary changes with no field changes
         MvChangesSingleDict dict1Changes = new MvChangesSingleDict("dict1");
         changes.addItem(dict1Changes);
 
-        MvRowFilter filter1 = changes.toFilter(handler, targetSingleDict);
-        MvRowFilter filter2 = changes.toFilter(handler, targetMultiDict);
-
-        // Should return null when no relevant changes
-        assertNull(filter1);
-        assertNull(filter2);
+        assertTrue(changes.isEmpty());
+        assertFalse(changes.hasKnownChanges("dict1"));
+        assertTrue(changes.toFilters(handler).isEmpty());
     }
 
     @Test
@@ -518,16 +519,12 @@ public class MvChangesMultiDictTest {
 
     @Test
     public void testNonExistentDictChanges() {
-        // Test: Changes for dictionary that doesn't exist in handler - test individual toFilter method to avoid NPE bug
+        // Test: Changes for dictionary that doesn't exist in handler
         MvChangesSingleDict nonExistentChanges = createDictChanges("non_existent", "field", 1L, 2L);
         changes.addItem(nonExistentChanges);
 
-        MvRowFilter filter1 = changes.toFilter(handler, targetSingleDict);
-        MvRowFilter filter2 = changes.toFilter(handler, targetMultiDict);
-
-        // Should return null when no relevant changes (non-existent dict not in handler)
-        assertNull(filter1);
-        assertNull(filter2);
+        assertTrue(changes.hasKnownChanges("non_existent"));
+        assertTrue(changes.toFilters(handler).isEmpty());
     }
 
     @Test

--- a/src/test/java/tech/ydb/mv/model/MvKeyCompareTest.java
+++ b/src/test/java/tech/ydb/mv/model/MvKeyCompareTest.java
@@ -11,9 +11,9 @@ import tech.ydb.table.values.DecimalType;
 import tech.ydb.table.values.PrimitiveType;
 
 /**
- * Comprehensive test for MvKey.compareTo() method.
+ * Comprehensive tests for MvKey and MvKeyPrefix comparison semantics.
  * Tests comparison with different key lengths (1, 2, 3) and data types
- * (Integer, Long, YdbBytes, String, BigDecimal).
+ * (Integer, Long, YdbBytes, String, BigDecimal), including prefix behavior.
  *
  * @author zinal
  */
@@ -341,16 +341,31 @@ public class MvKeyCompareTest {
     }
 
     @Test
-    public void testDifferentKeyLengthComparison() {
+    public void testCrossTableComparisonThrows() {
         MvTableInfo singleKeyTable = createSingleIntKeyTable("table1");
         MvTableInfo doubleKeyTable = createDoubleKeyTable("table2");
 
         MvKey key1 = createKey(YS().add("key1", 10), singleKeyTable.getKeyInfo());
         MvKey key2 = createKey(YS().add("key1", 10).add("key2", "apple"), doubleKeyTable.getKeyInfo());
 
-        // Should throw IllegalArgumentException when comparing keys with different lengths
+        // Should throw IllegalArgumentException when comparing keys from different tables.
         Assertions.assertThrows(IllegalArgumentException.class, () -> key1.compareTo(key2),
-                "Should throw exception when comparing keys with different lengths");
+                "Should throw exception when comparing keys from different tables");
+    }
+
+    @Test
+    public void testSameTableDifferentLengthComparisonUsesCommonPrefix() {
+        MvTableInfo singleKeyTable = createSingleIntKeyTable("table1");
+        MvTableInfo doubleKeyTable = createDoubleKeyTable("table1");
+
+        MvKey key1 = createKey(YS().add("key1", 10), singleKeyTable.getKeyInfo());
+        MvKey key2 = createKey(YS().add("key1", 10).add("key2", "apple"), doubleKeyTable.getKeyInfo());
+        MvKey key3 = createKey(YS().add("key1", 11).add("key2", "apple"), doubleKeyTable.getKeyInfo());
+
+        Assertions.assertEquals(0, key1.compareTo(key2),
+                "Same-table key prefixes compare by the available common key parts");
+        Assertions.assertTrue(key1.compareTo(key3) < 0,
+                "Different first key parts should still drive comparison");
     }
 
 }

--- a/src/test/java/tech/ydb/mv/model/SettingsTest.java
+++ b/src/test/java/tech/ydb/mv/model/SettingsTest.java
@@ -1,5 +1,7 @@
 package tech.ydb.mv.model;
 
+import java.util.Properties;
+
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import tech.ydb.mv.MvConfig;
@@ -13,23 +15,42 @@ public class SettingsTest {
     @Test
     public void checkDictionarySettings() {
         var src = new MvDictionarySettings();
-        System.out.println("dictionarySettings: " + MvConfig.GSON.toJson(src));
+
+        Assertions.assertEquals(10000, src.getRowsPerSecondLimit());
+        Assertions.assertEquals(500, src.getUpsertBatchSize());
+        Assertions.assertEquals(4, src.getCdcReaderThreads());
+        Assertions.assertEquals(100000, src.getMaxChangeRowsScanned());
 
         src.setRowsPerSecondLimit(600);
         src.setCdcReaderThreads(51);
         src.setUpsertBatchSize(123);
+        src.setMaxChangeRowsScanned(999);
 
         String temp = MvConfig.GSON.toJson(src);
 
         var dst = MvConfig.GSON.fromJson(temp, MvDictionarySettings.class);
 
         Assertions.assertEquals(src, dst);
+        Assertions.assertEquals(600, dst.getRowsPerSecondLimit());
+        Assertions.assertEquals(51, dst.getCdcReaderThreads());
+        Assertions.assertEquals(123, dst.getUpsertBatchSize());
+        Assertions.assertEquals(999, dst.getMaxChangeRowsScanned());
+
+        var copy = new MvDictionarySettings(src);
+        Assertions.assertEquals(src, copy);
     }
 
     @Test
     public void checkHandlerSettings() {
         var src = new MvHandlerSettings();
-        System.out.println("handlerSettings: " + MvConfig.GSON.toJson(src));
+
+        Assertions.assertEquals(4, src.getCdcReaderThreads());
+        Assertions.assertEquals(4, src.getApplyThreads());
+        Assertions.assertEquals(10000, src.getApplyQueueSize());
+        Assertions.assertEquals(1000, src.getSelectBatchSize());
+        Assertions.assertEquals(500, src.getUpsertBatchSize());
+        Assertions.assertEquals(28800, src.getDictionaryScanSeconds());
+        Assertions.assertEquals(30, src.getQueryTimeoutSeconds());
 
         src.setApplyQueueSize(123);
         src.setApplyThreads(456);
@@ -37,18 +58,24 @@ public class SettingsTest {
         src.setDictionaryScanSeconds(512);
         src.setSelectBatchSize(789);
         src.setUpsertBatchSize(333);
+        src.setQueryTimeoutSeconds(44);
 
         String temp = MvConfig.GSON.toJson(src);
 
         var dst = MvConfig.GSON.fromJson(temp, MvHandlerSettings.class);
 
         Assertions.assertEquals(src, dst);
+        Assertions.assertEquals(44, dst.getQueryTimeoutSeconds());
+
+        var copy = new MvHandlerSettings(src);
+        Assertions.assertEquals(src, copy);
     }
 
     @Test
     public void checkScanSettings() {
         var src = new MvScanSettings();
-        System.out.println("scanSettings: " + MvConfig.GSON.toJson(src));
+
+        Assertions.assertEquals(10000, src.getRowsPerSecondLimit());
 
         src.setRowsPerSecondLimit(500);
 
@@ -57,6 +84,38 @@ public class SettingsTest {
         var dst = MvConfig.GSON.fromJson(temp, MvScanSettings.class);
 
         Assertions.assertEquals(src, dst);
+    }
+
+    @Test
+    public void checkSettingsFromProperties() {
+        Properties props = new Properties();
+        props.setProperty(MvConfig.CONF_SCAN_RATE, "101");
+        props.setProperty(MvConfig.CONF_CDC_THREADS, "102");
+        props.setProperty(MvConfig.CONF_BATCH_UPSERT, "103");
+        props.setProperty(MvConfig.CONF_MAX_ROW_CHANGES, "104");
+        props.setProperty(MvConfig.CONF_APPLY_THREADS, "105");
+        props.setProperty(MvConfig.CONF_APPLY_QUEUE, "106");
+        props.setProperty(MvConfig.CONF_BATCH_SELECT, "107");
+        props.setProperty(MvConfig.CONF_DICT_SCAN_SECONDS, "108");
+        props.setProperty(MvConfig.CONF_QUERY_TIMEOUT, "109");
+
+        var dict = new MvDictionarySettings(props);
+        Assertions.assertEquals(101, dict.getRowsPerSecondLimit());
+        Assertions.assertEquals(102, dict.getCdcReaderThreads());
+        Assertions.assertEquals(103, dict.getUpsertBatchSize());
+        Assertions.assertEquals(104, dict.getMaxChangeRowsScanned());
+
+        var handler = new MvHandlerSettings(props);
+        Assertions.assertEquals(102, handler.getCdcReaderThreads());
+        Assertions.assertEquals(105, handler.getApplyThreads());
+        Assertions.assertEquals(106, handler.getApplyQueueSize());
+        Assertions.assertEquals(107, handler.getSelectBatchSize());
+        Assertions.assertEquals(103, handler.getUpsertBatchSize());
+        Assertions.assertEquals(108, handler.getDictionaryScanSeconds());
+        Assertions.assertEquals(109, handler.getQueryTimeoutSeconds());
+
+        var scan = new MvScanSettings(props);
+        Assertions.assertEquals(101, scan.getRowsPerSecondLimit());
     }
 
 }

--- a/src/test/java/tech/ydb/mv/parser/MvKeyPathGeneratorTest.java
+++ b/src/test/java/tech/ydb/mv/parser/MvKeyPathGeneratorTest.java
@@ -146,7 +146,7 @@ public class MvKeyPathGeneratorTest {
         MvColumn columnD = new MvColumn("d_value", new MvSqlPos(3, 1));
         columnD.setSourceAlias("d");
         columnD.setSourceColumn("value");
-        columnD.setSourceRef(sourceC);
+        columnD.setSourceRef(sourceD);
         columnD.setType(PrimitiveType.Text);
         originalTarget.getColumns().add(columnD);
 
@@ -178,7 +178,7 @@ public class MvKeyPathGeneratorTest {
 
     @Test
     public void testGenerateKeyPath_OneStep() {
-        // Test transformation from B to A (optimized - B has a_id foreign key)
+        // Test transformation from B to A through the A->B join condition
         MvViewExpr result = new MvPathGenerator(originalTarget).extractKeysReverse(sourceB);
         assertNotNull(result);
 
@@ -290,6 +290,12 @@ public class MvKeyPathGeneratorTest {
         }
 
         assertEquals(1, result.getSources().size()); // Optimized: only D needed
+        assertEquals("d", result.getSources().get(0).getTableAlias());
+        assertEquals(MvJoinMode.MAIN, result.getSources().get(0).getMode());
+        assertEquals(1, result.getColumns().size());
+        assertEquals("id", result.getColumns().get(0).getName());
+        assertEquals("d", result.getColumns().get(0).getSourceAlias());
+        assertEquals("a_id", result.getColumns().get(0).getSourceColumn());
     }
 
     @Test
@@ -342,5 +348,16 @@ public class MvKeyPathGeneratorTest {
         if (PRINT_SQL) {
             System.out.println("*** Literal condition SQL: " + new MvSqlGen(result).makeSelect());
         }
+
+        assertEquals(1, result.getLiterals().size());
+        assertNotNull(result.getLiteral("'AAA'"));
+
+        MvJoinSource bInResult = result.getSourceByAlias("b");
+        assertNotNull(bInResult);
+        assertTrue(bInResult.getConditions().stream()
+                .anyMatch(condition -> condition.getSecondLiteral() != null
+                && "'AAA'".equals(condition.getSecondLiteral().getValue())
+                && "some".equals(condition.getFirstColumn())),
+                "Literal join condition on b.some should be preserved in the generated path");
     }
 }

--- a/src/test/java/tech/ydb/mv/parser/SqlGenSelectUpsertTest.java
+++ b/src/test/java/tech/ydb/mv/parser/SqlGenSelectUpsertTest.java
@@ -5,9 +5,12 @@ import org.junit.jupiter.api.Test;
 
 import tech.ydb.mv.SqlConstants;
 import tech.ydb.mv.model.MvMetadata;
+import tech.ydb.mv.model.MvTableInfo;
+import tech.ydb.mv.model.MvViewExpr;
 
 /**
- * Test for MvSqlGen.makeSelect() and MvSqlGen.makeUpsert() methods
+ * Test for MvSqlGen.makeSelect(), makePlainUpsert(), makePlainDelete(), and
+ * makeConvertKeyToTarget() methods.
  *
  * @author zinal
  */
@@ -69,7 +72,105 @@ public class SqlGenSelectUpsertTest {
         validateGeneratedSelectSql2(generatedSql, target);
     }
 
-    private void addTableInfoToTarget(tech.ydb.mv.model.MvViewExpr target) {
+    @Test
+    public void testMakePlainUpsert1() {
+        MvViewExpr target = parseGood1Target();
+        MvTableInfo targetInfo = SqlConstants.tiTarget("m1");
+        addTargetTableInfo(target, targetInfo);
+
+        String generatedSql = new MvSqlGen(target).makePlainUpsert();
+
+        Assertions.assertTrue(generatedSql.startsWith("DECLARE " + MvSqlGen.SYS_INPUT_VAR + " AS List<Struct<"),
+                "UPSERT should declare input rows");
+        Assertions.assertTrue(generatedSql.contains("id:Int32"),
+                "Input declaration should contain target key type");
+        Assertions.assertTrue(generatedSql.contains("c10:Text"),
+                "Input declaration should contain target text fields");
+        Assertions.assertTrue(generatedSql.contains("UPSERT INTO m1" + MvSqlGen.EOL),
+                "UPSERT should target the materialized view");
+        Assertions.assertTrue(generatedSql.contains("SELECT * FROM AS_TABLE(" + MvSqlGen.SYS_INPUT_VAR + ");"),
+                "UPSERT should write rows from the sys_input table parameter");
+        Assertions.assertFalse(generatedSql.contains(MvSqlGen.SYS_KEYS_VAR),
+                "Plain UPSERT should not declare key-only input");
+    }
+
+    @Test
+    public void testMakePlainDeleteUsesSourceKeyForDirectDestinationKey() {
+        MvViewExpr target = parseGood1Target();
+        addTargetTableInfo(target, SqlConstants.tiTarget("m1"));
+
+        String generatedSql = new MvSqlGen(target).makePlainDelete();
+
+        Assertions.assertTrue(generatedSql.startsWith("DECLARE " + MvSqlGen.SYS_KEYS_VAR
+                + " AS List<Struct<id:Int32>>;"),
+                "Direct destination keys should use the top-most source key type");
+        Assertions.assertTrue(generatedSql.contains("DELETE FROM m1" + MvSqlGen.EOL));
+        Assertions.assertTrue(generatedSql.contains("ON SELECT * FROM AS_TABLE(" + MvSqlGen.SYS_KEYS_VAR + ");"));
+    }
+
+    @Test
+    public void testMakePlainDeleteUsesDestinationKeyWhenKeysDiffer() {
+        MvViewExpr target = parseGood1Target();
+        addTargetTableInfo(target, MvTableInfo.newBuilder("m1")
+                .addColumn("c8", tech.ydb.table.values.PrimitiveType.Text)
+                .addKey("c8")
+                .build());
+
+        String generatedSql = new MvSqlGen(target).makePlainDelete();
+
+        Assertions.assertTrue(generatedSql.startsWith("DECLARE " + MvSqlGen.SYS_KEYS_VAR
+                + " AS List<Struct<c8:Text>>;"),
+                "Non-direct destination keys should use the target table key type");
+        Assertions.assertTrue(generatedSql.contains("DELETE FROM m1" + MvSqlGen.EOL));
+    }
+
+    @Test
+    public void testMakeConvertKeyToTargetForDirectKeyMapping() {
+        MvViewExpr target = parseGood1Target();
+        addTargetTableInfo(target, SqlConstants.tiTarget("m1"));
+
+        String generatedSql = new MvSqlGen(target).makeConvertKeyToTarget();
+
+        Assertions.assertNotNull(generatedSql);
+        Assertions.assertTrue(generatedSql.startsWith("DECLARE " + MvSqlGen.SYS_KEYS_VAR
+                + " AS List<Struct<id:Int32>>;"));
+        Assertions.assertTrue(generatedSql.contains("SELECT main.id AS id FROM AS_TABLE("
+                + MvSqlGen.SYS_KEYS_VAR + ") AS main"));
+    }
+
+    @Test
+    public void testMakeConvertKeyToTargetReturnsNullForNonTopmostKey() {
+        MvViewExpr target = parseGood1Target();
+        addTargetTableInfo(target, MvTableInfo.newBuilder("m1")
+                .addColumn("c8", tech.ydb.table.values.PrimitiveType.Text)
+                .addKey("c8")
+                .build());
+
+        Assertions.assertNull(new MvSqlGen(target).makeConvertKeyToTarget(),
+                "Key conversion should be unavailable when the destination key is not mapped from the top source key");
+    }
+
+    private MvViewExpr parseGood1Target() {
+        MvMetadata mc = new MvSqlParser(SqlConstants.SQL_GOOD1).fill();
+        Assertions.assertTrue(mc.isValid());
+        Assertions.assertEquals(1, mc.getViews().size());
+        var view = mc.getViews().values().iterator().next();
+        var target = view.getParts().values().iterator().next();
+        addTableInfoToTarget(target);
+        return target;
+    }
+
+    private void addTargetTableInfo(MvViewExpr target, MvTableInfo targetInfo) {
+        target.setTableInfo(targetInfo);
+        for (var column : target.getColumns()) {
+            var type = targetInfo.getColumns().get(column.getName());
+            if (type != null) {
+                column.setType(type);
+            }
+        }
+    }
+
+    private void addTableInfoToTarget(MvViewExpr target) {
         target.getSources().get(0).setTableInfo(
                 SqlConstants.tiMainTable("main_table")
         );
@@ -84,7 +185,7 @@ public class SqlGenSelectUpsertTest {
         );
     }
 
-    private void addTableInfoToTarget2(tech.ydb.mv.model.MvViewExpr target) {
+    private void addTableInfoToTarget2(MvViewExpr target) {
         target.getSources().get(0).setTableInfo(
                 SqlConstants.tiMainTable("schema3/main_table")
         );
@@ -99,7 +200,7 @@ public class SqlGenSelectUpsertTest {
         );
     }
 
-    private void validateGeneratedSelectSql1(String sql, tech.ydb.mv.model.MvViewExpr target) {
+    private void validateGeneratedSelectSql1(String sql, MvViewExpr target) {
         // Check for DECLARE statement
         Assertions.assertTrue(sql.startsWith("DECLARE $"),
                 "SQL should start with DECLARE statement");
@@ -185,7 +286,7 @@ public class SqlGenSelectUpsertTest {
         }
     }
 
-    private void validateGeneratedSelectSql2(String sql, tech.ydb.mv.model.MvViewExpr target) {
+    private void validateGeneratedSelectSql2(String sql, MvViewExpr target) {
         // Check for DECLARE statement
         Assertions.assertTrue(sql.startsWith("DECLARE $"),
                 "SQL should start with DECLARE statement");
@@ -327,7 +428,7 @@ public class SqlGenSelectUpsertTest {
                 "SQL should contain sub3.c5 reference");
     }
 
-    private void validateConstantsUsage(String sql, tech.ydb.mv.model.MvViewExpr target) {
+    private void validateConstantsUsage(String sql, MvViewExpr target) {
         // Check that all literals are properly formatted in the constants subquery
         for (var literal : target.getLiterals()) {
             String value = literal.getValue();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Rebased onto current `origin/main` and dropped the stale base documentation commit from the PR branch.
- Strengthen worker selector tests to assert range distribution, distinct-prefix mapping, and hash routing behavior.
- Expand settings tests to assert defaults, JSON/copy round-trips, and property constructors.
- Add SQL generation tests for plain upsert/delete and key conversion paths.
- Tighten key-path and dictionary-change tests to assert preserved literals, filter block offsets, matches, and non-relevant changes.

## Testing
- `mvn -Dtest=MvWorkerSelectorTest,SettingsTest,SqlGenSelectUpsertTest,MvKeyPathGeneratorTest,MvChangesMultiDictTest,MvKeyCompareTest test`
- `mvn test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ecff8b75-5b09-4086-9df0-121441bb711f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ecff8b75-5b09-4086-9df0-121441bb711f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

