### PR TITLE
Fix direct key detection for delete handling

### DIFF
--- a/src/main/java/tech/ydb/mv/model/MvViewExpr.java
+++ b/src/main/java/tech/ydb/mv/model/MvViewExpr.java
@@ -221,13 +221,32 @@ public class MvViewExpr implements MvSqlPosHolder {
             return false;
         }
         for (String key : tableInfo.getKey()) {
-            var typeSrc = topMost.getColumns().get(key);
-            var typeDst = tableInfo.getColumns().get(key);
-            if (typeSrc == null || !typeSrc.equals(typeDst)) {
+            if (!isDirectTopmostKey(topMostSource, key)) {
                 return false;
             }
         }
         return true;
+    }
+
+    private boolean isDirectTopmostKey(MvJoinSource topMostSource, String keyName) {
+        MvColumn column = getColumnByName(keyName);
+        if (column == null || !column.isReference()) {
+            return false;
+        }
+        if (column.getSourceRef() != topMostSource) {
+            return false;
+        }
+        if (!keyName.equals(column.getSourceColumn())) {
+            return false;
+        }
+        var topMost = topMostSource.getTableInfo();
+        if (!topMost.getKey().contains(column.getSourceColumn())) {
+            return false;
+        }
+        var typeSrc = topMost.getColumns().get(column.getSourceColumn());
+        var tableInfo = getTableInfo();
+        var typeDst = tableInfo.getColumns().get(keyName);
+        return typeSrc != null && typeSrc.equals(typeDst);
     }
 
     @Override

--- a/src/main/java/tech/ydb/mv/model/MvViewExpr.java
+++ b/src/main/java/tech/ydb/mv/model/MvViewExpr.java
@@ -205,10 +205,10 @@ public class MvViewExpr implements MvSqlPosHolder {
     }
 
     /**
-     * Returns true when the destination table's primary key matches the topmost
-     * source's primary key (as mapped to output column names). When false,
-     * DELETE operations require key-based transformation to obtain full
-     * destination keys.
+     * Returns true when the destination table's primary key can reuse the
+     * topmost source CDC key unchanged. Computed or renamed keys can still be
+     * safe for DELETE processing, but they first need key conversion instead of
+     * this direct path.
      */
     public boolean isDestKeyDirect() {
         var topMostSource = getTopMostSource();

--- a/src/test/java/tech/ydb/mv/parser/SqlGenSelectUpsertTest.java
+++ b/src/test/java/tech/ydb/mv/parser/SqlGenSelectUpsertTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 
 import tech.ydb.mv.SqlConstants;
 import tech.ydb.mv.model.MvColumn;
+import tech.ydb.mv.model.MvComputation;
 import tech.ydb.mv.model.MvJoinMode;
 import tech.ydb.mv.model.MvJoinSource;
 import tech.ydb.mv.model.MvMetadata;
@@ -195,6 +196,38 @@ public class SqlGenSelectUpsertTest {
                 "Matching key names and types are not enough when the output key comes from a joined table");
         Assertions.assertNull(new MvSqlGen(target).makeConvertKeyToTarget(),
                 "Key conversion should still be unavailable for a secondary-table key");
+    }
+
+    @Test
+    public void testComputedTopmostKeyUsesKeyConversionForDelete() {
+        MvViewExpr target = new MvViewExpr("mv_computed_key");
+
+        MvJoinSource main = new MvJoinSource();
+        main.setTableName("main_table");
+        main.setTableAlias("main");
+        main.setMode(MvJoinMode.MAIN);
+        main.setTableInfo(MvTableInfo.newBuilder("main_table")
+                .addColumn("id", PrimitiveType.Int32)
+                .addKey("id")
+                .build());
+        target.getSources().add(main);
+
+        MvColumn id = new MvColumn("id");
+        id.setComputation(new MvComputation("main.id + 1000").addSource(main, "id"));
+        id.setType(PrimitiveType.Int32);
+        target.getColumns().add(id);
+
+        target.setTableInfo(MvTableInfo.newBuilder("mv_computed_key")
+                .addColumn("id", PrimitiveType.Int32)
+                .addKey("id")
+                .build());
+
+        Assertions.assertFalse(target.isDestKeyDirect(),
+                "Computed keys cannot reuse the source CDC key unchanged");
+        String convertSql = new MvSqlGen(target).makeConvertKeyToTarget();
+        Assertions.assertNotNull(convertSql,
+                "Computed keys from topmost source keys should be converted before DELETE");
+        Assertions.assertTrue(convertSql.contains("main.id + 1000 AS id"));
     }
 
     private MvViewExpr parseGood1Target() {

--- a/src/test/java/tech/ydb/mv/parser/SqlGenSelectUpsertTest.java
+++ b/src/test/java/tech/ydb/mv/parser/SqlGenSelectUpsertTest.java
@@ -4,9 +4,13 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import tech.ydb.mv.SqlConstants;
+import tech.ydb.mv.model.MvColumn;
+import tech.ydb.mv.model.MvJoinMode;
+import tech.ydb.mv.model.MvJoinSource;
 import tech.ydb.mv.model.MvMetadata;
 import tech.ydb.mv.model.MvTableInfo;
 import tech.ydb.mv.model.MvViewExpr;
+import tech.ydb.table.values.PrimitiveType;
 
 /**
  * Test for MvSqlGen.makeSelect(), makePlainUpsert(), makePlainDelete(), and
@@ -148,6 +152,49 @@ public class SqlGenSelectUpsertTest {
 
         Assertions.assertNull(new MvSqlGen(target).makeConvertKeyToTarget(),
                 "Key conversion should be unavailable when the destination key is not mapped from the top source key");
+    }
+
+    @Test
+    public void testDestKeyDirectRequiresActualTopmostKeyMapping() {
+        MvViewExpr target = new MvViewExpr("mv_mismapped_key");
+
+        MvJoinSource main = new MvJoinSource();
+        main.setTableName("main_table");
+        main.setTableAlias("main");
+        main.setMode(MvJoinMode.MAIN);
+        main.setTableInfo(MvTableInfo.newBuilder("main_table")
+                .addColumn("id", PrimitiveType.Int32)
+                .addColumn("sub_id", PrimitiveType.Int32)
+                .addKey("id")
+                .build());
+        target.getSources().add(main);
+
+        MvJoinSource sub = new MvJoinSource();
+        sub.setTableName("sub_table");
+        sub.setTableAlias("sub");
+        sub.setMode(MvJoinMode.INNER);
+        sub.setTableInfo(MvTableInfo.newBuilder("sub_table")
+                .addColumn("id", PrimitiveType.Int32)
+                .addKey("id")
+                .build());
+        target.getSources().add(sub);
+
+        MvColumn id = new MvColumn("id");
+        id.setSourceAlias("sub");
+        id.setSourceColumn("id");
+        id.setSourceRef(sub);
+        id.setType(PrimitiveType.Int32);
+        target.getColumns().add(id);
+
+        target.setTableInfo(MvTableInfo.newBuilder("mv_mismapped_key")
+                .addColumn("id", PrimitiveType.Int32)
+                .addKey("id")
+                .build());
+
+        Assertions.assertFalse(target.isDestKeyDirect(),
+                "Matching key names and types are not enough when the output key comes from a joined table");
+        Assertions.assertNull(new MvSqlGen(target).makeConvertKeyToTarget(),
+                "Key conversion should still be unavailable for a secondary-table key");
     }
 
     private MvViewExpr parseGood1Target() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Require destination primary keys to reuse the topmost source CDC key unchanged before treating DELETE keys as direct
- Keep computed/renamed topmost-key mappings on the key-conversion path instead of the direct fast path
- Add regression tests for both the joined-table same-name/same-type bug and the safe computed-topmost-key conversion case

## Testing
- `mvn -Dtest=SqlGenSelectUpsertTest test`
- `mvn test` (build success; integration test classes discovered zero runnable tests because Docker/Testcontainers is unavailable in this environment)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d1163847-e7ea-4959-bd36-de8a31c9eb59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d1163847-e7ea-4959-bd36-de8a31c9eb59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

