### PR TITLE
Handle incomplete CDC submit results

### DIFF
--- a/src/main/java/tech/ydb/mv/feeder/MvCdcEventReader.java
+++ b/src/main/java/tech/ydb/mv/feeder/MvCdcEventReader.java
@@ -120,7 +120,14 @@ class MvCdcEventReader extends AbstractReadEventHandler {
 
         long submitStart = System.nanoTime();
         try {
-            sink.submit(records, new MvCdcCommitHandler(this, event, records.size()));
+            MvCdcCommitHandler handler = new MvCdcCommitHandler(this, event, records.size());
+            boolean submitted = sink.submit(records, handler);
+            if (!submitted) {
+                LOG.error("Feeder `{}` for topic `{}` submitted only part of {} parsed CDC record(s); "
+                        + "leaving the topic event uncommitted for replay",
+                        owner.getName(), topicPath, records.size());
+                return;
+            }
             MvMetrics.recordCdcSubmit(scope, submitStart, records.size());
         } catch (Exception ex) {
             // We should not throw from onMessages(), as it stops the CDC reader.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Update `MvCdcEventReader` to check the boolean result from `sink.submit(...)`
- Treat an incomplete/failed submit as an uncommitted CDC event so it can be replayed instead of reporting submit success
- Log a clear error with feeder/topic/count context when the sink does not accept the full parsed batch

## Testing
- `mvn -DskipTests compile`
- `mvn test` (build success; integration test classes discovered zero runnable tests because Docker/Testcontainers is unavailable in this environment)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d1163847-e7ea-4959-bd36-de8a31c9eb59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d1163847-e7ea-4959-bd36-de8a31c9eb59"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

