### PR TITLE
Add unit tests for batch queue admission wiring

### DIFF
--- a/src/main/java/tech/ydb/mv/apply/MvApplyManager.java
+++ b/src/main/java/tech/ydb/mv/apply/MvApplyManager.java
@@ -5,8 +5,8 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import tech.ydb.table.TableClient;
 
@@ -33,8 +33,7 @@ public class MvApplyManager implements MvSink {
 
     private final MvActionContext context;
     private final MvApplyWorker[] workers;
-    private final AtomicInteger queueSize;
-    private final AtomicInteger batchQueueSize;
+    private final MvApplyQueueCounters queueCounters;
     private final MvApplyQueuePolicy queuePolicy;
 
     // source table name -> table apply configuration data
@@ -49,8 +48,7 @@ public class MvApplyManager implements MvSink {
         for (int i = 0; i < workerCount; ++i) {
             workers[i] = new MvApplyWorker(this, i);
         }
-        this.queueSize = new AtomicInteger(0);
-        this.batchQueueSize = new AtomicInteger(0);
+        this.queueCounters = new MvApplyQueueCounters();
         this.queuePolicy = new MvApplyQueuePolicy(
                 jobContext.getSettings().getApplyQueueSize(),
                 jobContext.getSettings().getApplyQueuePercent());
@@ -79,11 +77,11 @@ public class MvApplyManager implements MvSink {
     }
 
     public int getQueueSize() {
-        return queueSize.get();
+        return queueCounters.getQueueSize();
     }
 
     public int getBatchQueueSize() {
-        return batchQueueSize.get();
+        return queueCounters.getBatchQueueSize();
     }
 
     public int getMaxBatchQueueSize() {
@@ -91,26 +89,42 @@ public class MvApplyManager implements MvSink {
     }
 
     protected final int incrementQueueSize(boolean batch) {
-        if (batch) {
-            batchQueueSize.incrementAndGet();
-        }
-        return queueSize.incrementAndGet();
+        return queueCounters.increment(batch);
     }
 
     protected final int decrementQueueSize(int count, int batchCount) {
-        if (batchCount > 0) {
-            int batchTemp = batchQueueSize.addAndGet(-1 * batchCount);
-            if (batchTemp < 0) {
-                LOG.error("Batch queue size below zero: {}", batchTemp);
-                batchQueueSize.addAndGet(-1 * batchTemp);
+        return queueCounters.decrement(count, batchCount);
+    }
+
+    /**
+     * Detect whether a submission should be treated as batch work.
+     *
+     * @param changes Change records being submitted.
+     * @return {@code true} if at least one record is marked as batch.
+     */
+    static boolean detectBatchSubmission(Collection<MvChangeRecord> changes) {
+        for (MvChangeRecord change : changes) {
+            if (change.isBatch()) {
+                return true;
             }
         }
-        int temp = queueSize.addAndGet(-1 * count);
-        if (temp < 0) {
-            LOG.error("Queue size below zero: {}", temp);
-            return queueSize.addAndGet(-1 * temp);
+        return false;
+    }
+
+    /**
+     * Normalize batch markers so the whole submission shares one flag.
+     *
+     * @param changes Input change records.
+     * @param batch Desired batch marker for every record.
+     * @return Records with the normalized batch marker.
+     */
+    static List<MvChangeRecord> normalizeBatchFlag(
+            Collection<MvChangeRecord> changes, boolean batch) {
+        ArrayList<MvChangeRecord> normalized = new ArrayList<>(changes.size());
+        for (MvChangeRecord change : changes) {
+            normalized.add(change.withBatch(batch));
         }
-        return temp;
+        return normalized;
     }
 
     /**
@@ -230,21 +244,14 @@ public class MvApplyManager implements MvSink {
         if (actions == null) {
             actions = sourceConfig.getActions();
         }
-        boolean batch = false;
-        for (MvChangeRecord change : changes) {
-            if (change.isBatch()) {
-                batch = true;
-                break;
-            }
-        }
-        int count = changes.size();
-        ArrayList<MvApplyTask> curr = new ArrayList<>(count);
-        for (MvChangeRecord change : changes) {
+        boolean batch = detectBatchSubmission(changes);
+        List<MvChangeRecord> normalized = normalizeBatchFlag(changes, batch);
+        ArrayList<MvApplyTask> curr = new ArrayList<>(normalized.size());
+        for (MvChangeRecord change : normalized) {
             if (sourceConfig.getTableInfo() != change.getKey().getTableInfo()) {
                 throw new IllegalArgumentException("Mixed input tables on submission");
             }
-            // Normalize the whole submission to batch when any input is batch.
-            curr.add(new MvApplyTask(change.withBatch(batch), handler, actions));
+            curr.add(new MvApplyTask(change, handler, actions));
         }
         if (immediate) {
             // Forced path may overflow the queue (deadlock avoidance for

--- a/src/main/java/tech/ydb/mv/apply/MvApplyQueueCounters.java
+++ b/src/main/java/tech/ydb/mv/apply/MvApplyQueueCounters.java
@@ -1,0 +1,49 @@
+package tech.ydb.mv.apply;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Thread-safe counters for the apply queue size and its batch subset.
+ *
+ * @author zinal
+ */
+final class MvApplyQueueCounters {
+
+    private static final org.slf4j.Logger LOG
+            = org.slf4j.LoggerFactory.getLogger(MvApplyQueueCounters.class);
+
+    private final AtomicInteger queueSize = new AtomicInteger(0);
+    private final AtomicInteger batchQueueSize = new AtomicInteger(0);
+
+    int getQueueSize() {
+        return queueSize.get();
+    }
+
+    int getBatchQueueSize() {
+        return batchQueueSize.get();
+    }
+
+    int increment(boolean batch) {
+        if (batch) {
+            batchQueueSize.incrementAndGet();
+        }
+        return queueSize.incrementAndGet();
+    }
+
+    int decrement(int count, int batchCount) {
+        if (batchCount > 0) {
+            int batchTemp = batchQueueSize.addAndGet(-1 * batchCount);
+            if (batchTemp < 0) {
+                LOG.error("Batch queue size below zero: {}", batchTemp);
+                batchQueueSize.addAndGet(-1 * batchTemp);
+            }
+        }
+        int temp = queueSize.addAndGet(-1 * count);
+        if (temp < 0) {
+            LOG.error("Queue size below zero: {}", temp);
+            return queueSize.addAndGet(-1 * temp);
+        }
+        return temp;
+    }
+
+}

--- a/src/test/java/tech/ydb/mv/apply/ActionBaseHasBatchInputTest.java
+++ b/src/test/java/tech/ydb/mv/apply/ActionBaseHasBatchInputTest.java
@@ -1,0 +1,56 @@
+package tech.ydb.mv.apply;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import tech.ydb.mv.data.MvChangeRecord;
+import tech.ydb.mv.data.MvKey;
+import tech.ydb.mv.model.MvKeyInfo;
+import tech.ydb.mv.model.MvTableInfo;
+import tech.ydb.table.values.PrimitiveType;
+
+/**
+ * Unit tests for {@link ActionBase#hasBatchInput(List)}.
+ *
+ * @author zinal
+ */
+public class ActionBaseHasBatchInputTest {
+
+    private final MvKeyInfo keyInfo = MvTableInfo.newBuilder("t")
+            .addColumn("id", PrimitiveType.Int32)
+            .addKey("id")
+            .build()
+            .getKeyInfo();
+
+    @Test
+    public void hasBatchInputDetectsAnyBatchTask() {
+        Assertions.assertFalse(ActionBase.hasBatchInput(List.of()));
+        Assertions.assertFalse(ActionBase.hasBatchInput(List.of(task(1, false))));
+        Assertions.assertTrue(ActionBase.hasBatchInput(List.of(task(1, true))));
+        Assertions.assertTrue(ActionBase.hasBatchInput(
+                List.of(task(1, false), task(2, true), task(3, false))));
+    }
+
+    @Test
+    public void derivedRecordsShouldReuseHasBatchInputResult() {
+        // Mirrors Filter/Grab/Transform: one batch input makes all outputs batch.
+        boolean batch = ActionBase.hasBatchInput(List.of(task(1, false), task(2, true)));
+        MvChangeRecord derived = new MvChangeRecord(
+                new MvKey(keyInfo, new Comparable<?>[]{10}),
+                Instant.parse("2026-01-01T00:00:00Z"))
+                .withBatch(batch);
+
+        Assertions.assertTrue(derived.isBatch());
+    }
+
+    private MvApplyTask task(int id, boolean batch) {
+        MvKey key = new MvKey(keyInfo, new Comparable<?>[]{id});
+        MvChangeRecord record = new MvChangeRecord(key, Instant.parse("2026-01-01T00:00:00Z"))
+                .withBatch(batch);
+        return new MvApplyTask(record, null, List.of(), 0);
+    }
+
+}

--- a/src/test/java/tech/ydb/mv/apply/MvApplyBatchNormalizationTest.java
+++ b/src/test/java/tech/ydb/mv/apply/MvApplyBatchNormalizationTest.java
@@ -1,0 +1,75 @@
+package tech.ydb.mv.apply;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import tech.ydb.mv.data.MvChangeRecord;
+import tech.ydb.mv.data.MvKey;
+import tech.ydb.mv.model.MvKeyInfo;
+import tech.ydb.mv.model.MvTableInfo;
+import tech.ydb.table.values.PrimitiveType;
+
+/**
+ * Unit tests for batch detection/normalization used by {@link MvApplyManager}.
+ *
+ * @author zinal
+ */
+public class MvApplyBatchNormalizationTest {
+
+    private final MvKeyInfo keyInfo = MvTableInfo.newBuilder("t")
+            .addColumn("id", PrimitiveType.Int32)
+            .addKey("id")
+            .build()
+            .getKeyInfo();
+
+    @Test
+    public void detectBatchSubmissionRequiresAtLeastOneBatchRecord() {
+        MvChangeRecord interactive = record(1, false);
+        MvChangeRecord batch = record(2, true);
+
+        Assertions.assertFalse(MvApplyManager.detectBatchSubmission(List.of()));
+        Assertions.assertFalse(MvApplyManager.detectBatchSubmission(List.of(interactive)));
+        Assertions.assertTrue(MvApplyManager.detectBatchSubmission(List.of(batch)));
+        Assertions.assertTrue(MvApplyManager.detectBatchSubmission(
+                List.of(interactive, batch)));
+    }
+
+    @Test
+    public void normalizeBatchFlagMarksWholeSubmission() {
+        MvChangeRecord interactive = record(1, false);
+        MvChangeRecord batch = record(2, true);
+
+        List<MvChangeRecord> asBatch = MvApplyManager.normalizeBatchFlag(
+                List.of(interactive, batch), true);
+        Assertions.assertEquals(2, asBatch.size());
+        Assertions.assertTrue(asBatch.get(0).isBatch());
+        Assertions.assertTrue(asBatch.get(1).isBatch());
+        Assertions.assertFalse(interactive.isBatch());
+
+        List<MvChangeRecord> asInteractive = MvApplyManager.normalizeBatchFlag(
+                List.of(batch), false);
+        Assertions.assertEquals(1, asInteractive.size());
+        Assertions.assertFalse(asInteractive.get(0).isBatch());
+        Assertions.assertTrue(batch.isBatch());
+    }
+
+    @Test
+    public void mixedSubmissionFollowsDetectThenNormalizePath() {
+        List<MvChangeRecord> input = List.of(record(1, false), record(2, true), record(3, false));
+        boolean batch = MvApplyManager.detectBatchSubmission(input);
+        List<MvChangeRecord> normalized = MvApplyManager.normalizeBatchFlag(input, batch);
+
+        Assertions.assertTrue(batch);
+        Assertions.assertTrue(normalized.stream().allMatch(MvChangeRecord::isBatch));
+    }
+
+    private MvChangeRecord record(int id, boolean batch) {
+        MvKey key = new MvKey(keyInfo, new Comparable<?>[]{id});
+        return new MvChangeRecord(key, Instant.parse("2026-01-01T00:00:00Z"))
+                .withBatch(batch);
+    }
+
+}

--- a/src/test/java/tech/ydb/mv/apply/MvApplyQueueCountersTest.java
+++ b/src/test/java/tech/ydb/mv/apply/MvApplyQueueCountersTest.java
@@ -1,0 +1,111 @@
+package tech.ydb.mv.apply;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for apply-queue size accounting.
+ *
+ * @author zinal
+ */
+public class MvApplyQueueCountersTest {
+
+    @Test
+    public void tracksInteractiveAndBatchSeparately() {
+        MvApplyQueueCounters counters = new MvApplyQueueCounters();
+
+        counters.increment(false);
+        counters.increment(true);
+        counters.increment(true);
+
+        Assertions.assertEquals(3, counters.getQueueSize());
+        Assertions.assertEquals(2, counters.getBatchQueueSize());
+
+        counters.decrement(3, 2);
+
+        Assertions.assertEquals(0, counters.getQueueSize());
+        Assertions.assertEquals(0, counters.getBatchQueueSize());
+    }
+
+    @Test
+    public void drainLeavesRemainingBatchCountIntact() {
+        MvApplyQueueCounters counters = new MvApplyQueueCounters();
+        for (int i = 0; i < 5; ++i) {
+            counters.increment(true);
+        }
+        counters.increment(false);
+
+        // Simulate one worker drain that took 2 batch + 1 interactive.
+        counters.decrement(3, 2);
+
+        Assertions.assertEquals(3, counters.getQueueSize());
+        Assertions.assertEquals(3, counters.getBatchQueueSize());
+    }
+
+    @Test
+    public void clampsCountersWhenDecrementGoesBelowZero() {
+        MvApplyQueueCounters counters = new MvApplyQueueCounters();
+        counters.increment(true);
+
+        counters.decrement(5, 5);
+
+        Assertions.assertEquals(0, counters.getQueueSize());
+        Assertions.assertEquals(0, counters.getBatchQueueSize());
+    }
+
+    @Test
+    public void supportsForceStyleOverflowAbovePolicyCap() {
+        MvApplyQueuePolicy policy = new MvApplyQueuePolicy(1000, 40);
+        MvApplyQueueCounters counters = new MvApplyQueueCounters();
+
+        for (int i = 0; i < policy.getMaxBatchQueue(); ++i) {
+            Assertions.assertTrue(policy.canAdmit(true,
+                    counters.getQueueSize(), counters.getBatchQueueSize()));
+            counters.increment(true);
+        }
+
+        Assertions.assertFalse(policy.canAdmit(true,
+                counters.getQueueSize(), counters.getBatchQueueSize()));
+
+        // Forced fan-out may still enqueue and must keep counters consistent.
+        counters.increment(true);
+        Assertions.assertEquals(policy.getMaxBatchQueue() + 1, counters.getQueueSize());
+        Assertions.assertEquals(policy.getMaxBatchQueue() + 1, counters.getBatchQueueSize());
+
+        // Interactive work remains admissible while total is below queueLimit.
+        Assertions.assertTrue(policy.canAdmit(false,
+                counters.getQueueSize(), counters.getBatchQueueSize()));
+        counters.increment(false);
+        Assertions.assertEquals(policy.getMaxBatchQueue() + 2, counters.getQueueSize());
+        Assertions.assertEquals(policy.getMaxBatchQueue() + 1, counters.getBatchQueueSize());
+    }
+
+    @Test
+    public void interactiveRemainsAdmissibleWhenBatchIsAtCap() {
+        MvApplyQueuePolicy policy = new MvApplyQueuePolicy(1000, 40);
+        MvApplyQueueCounters counters = new MvApplyQueueCounters();
+
+        for (int i = 0; i < policy.getMaxBatchQueue(); ++i) {
+            counters.increment(true);
+        }
+
+        Assertions.assertFalse(policy.canAdmit(true,
+                counters.getQueueSize(), counters.getBatchQueueSize()));
+        Assertions.assertTrue(policy.canAdmit(false,
+                counters.getQueueSize(), counters.getBatchQueueSize()));
+
+        int reserved = policy.getQueueLimit() - policy.getMaxBatchQueue();
+        for (int i = 0; i < reserved; ++i) {
+            Assertions.assertTrue(policy.canAdmit(false,
+                    counters.getQueueSize(), counters.getBatchQueueSize()));
+            counters.increment(false);
+        }
+
+        Assertions.assertEquals(policy.getQueueLimit(), counters.getQueueSize());
+        Assertions.assertFalse(policy.canAdmit(false,
+                counters.getQueueSize(), counters.getBatchQueueSize()));
+        Assertions.assertFalse(policy.canAdmit(true,
+                counters.getQueueSize(), counters.getBatchQueueSize()));
+    }
+
+}

--- a/src/test/java/tech/ydb/mv/apply/MvApplyTaskBatchTest.java
+++ b/src/test/java/tech/ydb/mv/apply/MvApplyTaskBatchTest.java
@@ -1,0 +1,38 @@
+package tech.ydb.mv.apply;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import tech.ydb.mv.data.MvChangeRecord;
+import tech.ydb.mv.data.MvKey;
+import tech.ydb.mv.model.MvKeyInfo;
+import tech.ydb.mv.model.MvTableInfo;
+import tech.ydb.table.values.PrimitiveType;
+
+/**
+ * Unit tests for batch marker exposure on {@link MvApplyTask}.
+ *
+ * @author zinal
+ */
+public class MvApplyTaskBatchTest {
+
+    private final MvKeyInfo keyInfo = MvTableInfo.newBuilder("t")
+            .addColumn("id", PrimitiveType.Int32)
+            .addKey("id")
+            .build()
+            .getKeyInfo();
+
+    @Test
+    public void isBatchDelegatesToChangeRecord() {
+        MvKey key = new MvKey(keyInfo, new Comparable<?>[]{1});
+        MvChangeRecord interactive = new MvChangeRecord(key, Instant.now());
+        MvChangeRecord batch = interactive.withBatch(true);
+
+        Assertions.assertFalse(new MvApplyTask(interactive, null, List.of(), 0).isBatch());
+        Assertions.assertTrue(new MvApplyTask(batch, null, List.of(), 0).isBatch());
+    }
+
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #7: add the missing unit coverage for batch/interactive apply-queue wiring.

### Tests added
- **`MvApplyQueueCountersTest`** — total/batch counters, drain accounting, below-zero clamp, force-style overflow above batch cap, interactive still admissible while batch is at cap
- **`MvApplyBatchNormalizationTest`** — `detectBatchSubmission` / `normalizeBatchFlag` for mixed submissions
- **`ActionBaseHasBatchInputTest`** — shared `hasBatchInput` helper used by Filter/Grab/Transform
- **`MvApplyTaskBatchTest`** — `MvApplyTask.isBatch()` delegates to the change record

### Small production seams
- Extracted **`MvApplyQueueCounters`** from `MvApplyManager`
- Moved detection/normalization into package-visible helpers used by `doSubmit`

No end-to-end “STREAM during dictionary refresh” test yet — that still needs a fuller handler fixture and is left out of this PR.

## Test plan
- [x] `mvn -Dtest=MvApplyQueueCountersTest,MvApplyBatchNormalizationTest,ActionBaseHasBatchInputTest,MvApplyTaskBatchTest,MvApplyQueuePolicyTest,MvChangeRecordBatchTest,SettingsTest test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0574648a-25c0-4f23-b3e4-5e71d7c6db02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0574648a-25c0-4f23-b3e4-5e71d7c6db02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

